### PR TITLE
make freebsd_host role host type aware

### DIFF
--- a/freebsd_host/defaults/main.yml
+++ b/freebsd_host/defaults/main.yml
@@ -1,18 +1,22 @@
 ---
 default_host_packages:
-  - "smartmontools"
   - "pftop"
   - "openntpd"
+  - "dmidecode"
+  - "netdata"
+
+default_hardware_host_packages:
+  - "smartmontools"
   - "beadm"
   - "zfs-periodic"
-  - "netdata"
   - "zfs-stats"
-  - "dmidecode"
+
+default_vmware_host_packages:
+  - "open-vm-tools-nox11"
 
 ntp_servers:
   - "dk.pool.ntp.org"
 
-smartd: yes
 smartd_email: "admin@example.com"
 
 zfs_periodic_pools:
@@ -30,4 +34,5 @@ zfs_scrub_interval_days: 30
 tykbackup_client: yes
 pf_host: yes
 
-
+# types: [hardware, vmware]
+host_type: hardware

--- a/freebsd_host/defaults/main.yml
+++ b/freebsd_host/defaults/main.yml
@@ -4,12 +4,12 @@ default_host_packages:
   - "openntpd"
   - "dmidecode"
   - "netdata"
+  - "zfs-periodic"
+  - "zfs-stats"
 
 default_hardware_host_packages:
   - "smartmontools"
   - "beadm"
-  - "zfs-periodic"
-  - "zfs-stats"
 
 default_vmware_host_packages:
   - "open-vm-tools-nox11"

--- a/freebsd_host/tasks/main.yml
+++ b/freebsd_host/tasks/main.yml
@@ -2,11 +2,14 @@
 - include_tasks: "packages.yml"
 - include_tasks: "openntpd.yml"
 - include_tasks: "smartd.yml"
-  when: smartd
+  when: host_type is hardware
 - include_tasks: "zfs-periodic.yml"
+  when: host_type is hardware
 - include_tasks: "zfs-scrub.yml"
+  when: host_type is hardware
 - include_tasks: "netdata.yml"
 - include_tasks: "aesni.yml"
+  when: host_type is hardware
 - include_tasks: "sysctl.yml"
 - include_tasks: "arc_max.yml"
 

--- a/freebsd_host/tasks/main.yml
+++ b/freebsd_host/tasks/main.yml
@@ -4,12 +4,9 @@
 - include_tasks: "smartd.yml"
   when: host_type is hardware
 - include_tasks: "zfs-periodic.yml"
-  when: host_type is hardware
 - include_tasks: "zfs-scrub.yml"
-  when: host_type is hardware
 - include_tasks: "netdata.yml"
 - include_tasks: "aesni.yml"
-  when: host_type is hardware
 - include_tasks: "sysctl.yml"
 - include_tasks: "arc_max.yml"
 

--- a/freebsd_host/tasks/packages.yml
+++ b/freebsd_host/tasks/packages.yml
@@ -3,5 +3,5 @@
   pkgng:
     name: "{{ item }}"
     state: present
-  with_items: "{{ default_host_packages }} + default_{{ host_type }}_host_packages + {{ extra_host_packages | default([]) }}"
+  with_items: "{{ default_host_packages }} + {{ default_{{ host_type }}_host_packages }} + {{ extra_host_packages | default([]) }}"
 

--- a/freebsd_host/tasks/packages.yml
+++ b/freebsd_host/tasks/packages.yml
@@ -3,5 +3,5 @@
   pkgng:
     name: "{{ item }}"
     state: present
-  with_items: "{{ default_host_packages }} + {{ extra_host_packages | default([]) }}"
+  with_items: "{{ default_host_packages }} + default_{{ host_type }}_host_packages + {{ extra_host_packages | default([]) }}"
 


### PR DESCRIPTION
Adds a host_type variable to determine if the role is played against an
host running on hardware or virtual (vmware for now). Removes smartd
variable since it should no longer be needed.