### PR TITLE
Fix bug with package installation and introduce zfs_arc_max_defaults

### DIFF
--- a/freebsd_host/defaults/main.yml
+++ b/freebsd_host/defaults/main.yml
@@ -29,6 +29,10 @@ zfs_periodic_retention:
   weekly: 8
   monthly: 15
 
+zfs_arc_max_defaults:
+  hardware: 10G
+  vmware: 512M
+
 zfs_scrub_interval_days: 30
 
 tykbackup_client: yes

--- a/freebsd_host/tasks/arc_max.yml
+++ b/freebsd_host/tasks/arc_max.yml
@@ -2,6 +2,6 @@
 - name: "Set vfs.zfs.arc_max in /boot/loader.conf"
   sysrc:
     name: "vfs.zfs.arc_max"
-    value: "{{ zfs_arc_max }}"
+    value: "{{ zfs_arc_max | d(zfs_arc_max_defaults[host_type]) }}"
     dest: "/boot/loader.conf"
 

--- a/freebsd_host/tasks/main.yml
+++ b/freebsd_host/tasks/main.yml
@@ -2,7 +2,7 @@
 - include_tasks: "packages.yml"
 - include_tasks: "openntpd.yml"
 - include_tasks: "smartd.yml"
-  when: host_type is hardware
+  when: host_type == "hardware"
 - include_tasks: "zfs-periodic.yml"
 - include_tasks: "zfs-scrub.yml"
 - include_tasks: "netdata.yml"

--- a/freebsd_host/tasks/packages.yml
+++ b/freebsd_host/tasks/packages.yml
@@ -3,5 +3,5 @@
   pkgng:
     name: "{{ item }}"
     state: present
-  with_items: "{{ default_host_packages }} + {{ default_{{ host_type }}_host_packages }} + {{ extra_host_packages | default([]) }}"
+  with_items: "{{ default_host_packages }} + {{ 'default_' + host_type + '_host_packages' }} + {{ extra_host_packages | default([]) }}"
 


### PR DESCRIPTION
This fixes a few bugs introduced in the last PR, woops - sorry! Also it introduces a zfs_arc_max_defaults dict with somewhat sane values which is used when no zfs_arc_max is provided.