### PR TITLE
add ldap and sqlite3 support to grafana role

### DIFF
--- a/grafana_server/defaults/main.yml
+++ b/grafana_server/defaults/main.yml
@@ -1,6 +1,4 @@
 ---
-grafana_postgres_host: "{{ postgres_host }}"
-
 nginx_locationslash: |
  location / {
       proxy_pass http://127.0.0.1:3000;
@@ -11,4 +9,7 @@ nginx_locationslash: |
 
 # http://docs.grafana.org/installation/configuration/#url
 #grafana_database_url: 
+
+# LDAP can be enabled by defining grafana_ldap_config: http://docs.grafana.org/auth/ldap/
+grafana_ldap_config_path: /usr/local/etc/grafana-ldap.toml
 

--- a/grafana_server/tasks/grafana.yml
+++ b/grafana_server/tasks/grafana.yml
@@ -14,6 +14,17 @@
   notify:
     - "restart grafana"
 
+- name: "Install Grafana ldap config"
+  copy:
+    content: "{{ grafana_ldap_config }}"
+    dest: "{{ grafana_ldap_config_path }}"
+    owner: "root"
+    group: "wheel"
+    mode: "0755"
+  when: grafana_ldap_config is defined
+  notify:
+    - "restart grafana"
+
 - name: "Create supervisord.d config file to run grafana"
   include_role:
     name: "supervisord_server"
@@ -26,3 +37,10 @@
         command: "/usr/local/bin/grafana-server -config=/usr/local/etc/grafana.conf -homepath=/usr/local/share/grafana/"
         user: "grafana"
 
+- name: "Make sure grafana data directory exists"
+  file:
+    path: "/var/db/grafana"
+    state: "directory"
+    owner: "grafana"
+    group: "grafana"
+    mode: "0755"

--- a/grafana_server/templates/grafana.conf.j2
+++ b/grafana_server/templates/grafana.conf.j2
@@ -25,7 +25,7 @@ path = grafana.db
 {% if grafana_ldap_config is defined  %}
 [auth.ldap]
 enabled = true
-config_file = {{ grafana_ldap_config_dir }}
+config_file = {{ grafana_ldap_config_path }}
 {% endif %}
 
 [session]

--- a/grafana_server/templates/grafana.conf.j2
+++ b/grafana_server/templates/grafana.conf.j2
@@ -10,12 +10,22 @@ root_url = {{ grafana_root_url }}
 [database]
 {% if grafana_database_url is defined %}
 url = {{ grafana_database_url }}
-{% else %}
+{% elif grafana_postgres_host is defined %}
 type = postgres
 host = {{ grafana_postgres_host }}:5432
 name = {{ grafana_postgres_dbname }}
 user = {{ grafana_postgres_user }}
 password = {{ grafana_postgres_password }}
+{% else %}
+type = sqlite3
+# This path is relative to paths.data
+path = grafana.db
+{% endif %}
+
+{% if grafana_ldap_config is defined  %}
+[auth.ldap]
+enabled = true
+config_file = {{ grafana_ldap_config_dir }}
 {% endif %}
 
 [session]


### PR DESCRIPTION
This also removes the default grafana_postgres_host since the role fails
when that variable is not defined.