### PR TITLE
ignore errors when attempting to load aesni

### DIFF
--- a/handlers/handlers/kldload-aesni.yml
+++ b/handlers/handlers/kldload-aesni.yml
@@ -1,4 +1,5 @@
 ---
 - name: "load AESNI module"
   command: "/sbin/kldload aesni"
+  ignore_errors: yes
 


### PR DESCRIPTION
On my latest 11.2-RELEASE install the aesni kernel module was loaded by
default so this failed.