### PR TITLE
reintroduce auth.ldap if grafana_ldap_config is defined

### DIFF
--- a/grafana_server/templates/grafana.conf.j2
+++ b/grafana_server/templates/grafana.conf.j2
@@ -10,6 +10,12 @@ root_url = {{ grafana_root_url }}
 [database]
 url = {{ grafana_database_url }}
 
+{% if grafana_ldap_config is defined  %}
+[auth.ldap]
+enabled = true
+config_file = {{ grafana_ldap_config_path }}
+{% endif %}
+
 [session]
 provider = file
 


### PR DESCRIPTION
I accidentally deleted these lines when doing the change to only using
database url.