### PR TITLE
nginx_server: prime_nginx_ocsp.sh: no error on http-only sites

### DIFF
--- a/nginx_server/files/prime_nginx_ocsp.sh
+++ b/nginx_server/files/prime_nginx_ocsp.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-for vhost in $(ls -1 /usr/local/etc/nginx/vhosts/*https.conf | rev | cut -d "/" -f 1 | rev | sed "s/-https.conf$//"); do
+for vhost in $(find /usr/local/etc/nginx/vhosts/ -type f -name '*https.conf' | rev | cut -d "/" -f 1 | rev | sed "s/-https.conf$//"); do
         echo -e "GET /__nginx_ocsp_priming/ HTTP/1.1\r\nhost: ${vhost}\r\n" | /usr/local/bin/openssl s_client -connect ${vhost}:443 -servername ${vhost} -status > /dev/null 2>&1
 done


### PR DESCRIPTION
When you have no nginx config files with the `https.conf` suffix, the OCSP priming task fails, causing cron to send spam mail.

This PR replaces the ls command with a `find` invocation that exits successfully when no files are found.