### PR TITLE
Append fixed hostname to each domainset

### DIFF
--- a/certgrinderd_server/templates/authorized_keys.j2
+++ b/certgrinderd_server/templates/authorized_keys.j2
@@ -1,3 +1,3 @@
 {% for key, value in certgrinderd_authorized_keys.items() %}
-from="{% if value.fromip is string %}{{ value.fromip }}{% else %}{{ value.fromip|join(",") }}{% endif %}",environment="CERTGRINDERD_DOMAINSETS={% for ds in value.domainsets %}{% if ds is string %}{{ ds }}{% else %}{{ ds|join(",") }}{% endif %};{% endfor %}",command="/usr/local/bin/certgrinderd $SSH_ORIGINAL_COMMAND",restrict {{ value.authkey }}
+from="{% if value.fromip is string %}{{ value.fromip }}{% else %}{{ value.fromip|join(",") }}{% endif %}",environment="CERTGRINDERD_DOMAINSETS={% for ds in value.domainsets %}{% if ds is string %}{{ ds }}{% else %}{{ ds|join(",") }}{% endif %}{% if value.append_to_each_domainset is string %},{{ value.append_to_each_domainset }}{% endif %};{% endfor %}",command="/usr/local/bin/certgrinderd $SSH_ORIGINAL_COMMAND",restrict {{ value.authkey }}
 {% endfor %}


### PR DESCRIPTION
When you have multiple reverse proxy servers, and you don't want to copy the private keys, you will run into a limitation of having 5 certificates, with the same set of hostnames, signed by LetsEncrypt a week. The PR adds the option to append a fixed host at the end of each domainset.

Example of `group_vars`:
```
certgrinderd_authorized_keys:
  webproxy2_example_com:
    fromip: "2001:DB8::15"
    authkey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOegnR+qnK2FEoaSrVwHgCIxjFkVEbW4VO31/Hd2mAwk ansible-generated on webproxy2.example.com"
    append_to_each_domainset: "webproxy2.example.com"
    domainsets:
      - example.com,www.example.com
      - example.net
```

The result in `authorized_keys` will look something like this:
```
from="2001:DB8::15",environment="CERTGRINDERD_DOMAINSETS=example.com,www.example.com,webproxy2.example.com;example.net,webproxy2.example.com",command="/path/to/certgrinderd $SSH_ORIGINAL_COMMAND",restrict ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOegnR+qnK2FEoaSrVwHgCIxjFkVEbW4VO31/Hd2mAwk ansible-generated on webproxy2.example.com
```