### PR TITLE
option to set retention size flag in supervisord config file for prometheus

### DIFF
--- a/prometheus_server/defaults/main.yml
+++ b/prometheus_server/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 prometheus_retention_days: 3650
+prometheus_retention_size: 0
 prometheus_alertmanager_scheme: "http"
 prometheus_basic_auth_users: []
 

--- a/prometheus_server/tasks/supervisord.yml
+++ b/prometheus_server/tasks/supervisord.yml
@@ -8,6 +8,6 @@
     supervisord_programs:
       - name: "prometheus"
         comment: "run prometheus"
-        command: "/usr/local/bin/prometheus --config.file=/usr/local/etc/prometheus.yml --storage.tsdb.path=/var/db/prometheus --storage.tsdb.retention.time={{ prometheus_retention_days }}d --web.external-url={{ prometheus_external_url }} --web.config.file=/usr/local/etc/prometheus-web.yml --web.enable-remote-write-receiver"
+        command: "/usr/local/bin/prometheus --config.file=/usr/local/etc/prometheus.yml --storage.tsdb.path=/var/db/prometheus --storage.tsdb.retention.time={{ prometheus_retention_days }}d --storage.tsdb.retention.size={{ prometheus_retention_size }} --web.external-url={{ prometheus_external_url }} --web.config.file=/usr/local/etc/prometheus-web.yml --web.enable-remote-write-receiver"
         user: "prometheus"
 


### PR DESCRIPTION
Defaults for variable set to 0 as per [documentation](https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects):

--storage.tsdb.retention.size: The maximum number of bytes of storage blocks to retain. The oldest data will be removed first. Defaults to 0 or disabled.
